### PR TITLE
updating dockerfile and readme with info on COPY and wildcards in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:8.2.0-alpine
 RUN mkdir -p /usr/src/app
-COPY ./app/* /usr/src/app/
+COPY ./app/ /usr/src/app/
 WORKDIR /usr/src/app
 RUN npm install
 CMD node /usr/src/app/index.js

--- a/README.md
+++ b/README.md
@@ -15,6 +15,26 @@ COPY pic-?.jpg /myDir/    # adds all files that match the pattern, e.g. pic-1.jp
 
 When copying entire directories, avoid using the wildcard `*` after the source directory path (e.g. `./dir/*`). This will copy all files in all subdirectories, but **will not maintain the original directory structure when moved to the destination folder**. Instead you can just leave it out as `COPY ./dir/ /myDir/`. This will maintain the directory structure of your application inside the container.
 
+# Debugging Docker Containers
+Application not running? Take a look inside your container to see why. First list containers. Using the `-l` argument with `docker ps` will show all containers whether or not they are running. This is particularly useful if your application is crashing.
+
+```bash
+docker ps -l
+
+CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                             NAMES
+d73e9071a2d0        aci-hello-world     "npm start"         10 seconds ago      Up 10 seconds       8080/tcp, 0.0.0.0:8080->80/tcp    keen_jepsen
+```
+
+If your container has a statys of `Exited(1)` you know something has gone wrong. Take a look at your application logs using the `docker logs` command to debug. If there are any application errors, they will be shown here.
+
+```bash
+docker logs d73e9071a2d0
+
+app@0.0.0 start /usr/src/app
+node index.js
+```
+
+
 # Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ This sample is a very simple NodeJS application used to demonstrate [Azure Conta
 
 The packaged version of the application is [available on Docker Hub](https://hub.docker.com/r/microsoft/aci-helloworld/).
 
+# Note
+
+Most, if not all, Dockerfiles contain commands that copy your source code to the container. It is helpful to note that when copying files from your application into the container, you can use wildcard characters such as `*` and `?`. The `*` character will add all files to the destination directory that match it's pattern. The `?` character will do the same but can only be replaced by a single character.
+
+```Dockerfile
+COPY *.jpg /myDir/        # adds all jpg files to /myDir/
+COPY pic-?.jpg /myDir/    # adds all files that match the pattern, e.g. pic-1.jpg, pic-2.jpg
+```
+
+When copying entire directories, avoid using the wildcard `*` after the source directory path (e.g. `./dir/*`). This will copy all files in all subdirectories, but **will not maintain the original directory structure when moved to the destination folder**. Instead you can just leave it out as `COPY ./dir/ /myDir/`. This will maintain the directory structure of your application inside the container.
 
 # Contributing
 


### PR DESCRIPTION
The old notation for the Docker COPY statement in the Dockerfile does not maintain directory structure when moved to the destination folder. This is fine for the aci-helloworld sample, but any other application with files in one or more directory will break as a result of this. I've updated the sample Dockerfile and provided a bit of detail into the COPY command and wildcard characters.