### PR TITLE
Update Node LTS image version to 8.9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.2.0-alpine
+FROM node:8.9.3-alpine
 RUN mkdir -p /usr/src/app
 COPY ./app/* /usr/src/app/
 WORKDIR /usr/src/app


### PR DESCRIPTION
This version includes security updates, see:
https://nodejs.org/en/blog/vulnerability/oct-2017-dos/

The change of Node version has is transparent to the sample app.

Thanks!

Here is the output from the build:

```sh
Sending build context to Docker daemon  129.5kB
Step 1/6 : FROM node:8.9.3-alpine
8.9.3-alpine: Pulling from library/node
1160f4abea84: Pull complete 
66ff3f133e43: Pull complete 
4c8ff6f0a4db: Pull complete 
Digest: sha256:40201c973cf40708f06205b22067f952dd46a29cecb7a74b873ce303ad0d11a5
Status: Downloaded newer image for node:8.9.3-alpine
 ---> 144aaf4b1367
Step 2/6 : RUN mkdir -p /usr/src/app
 ---> Running in 2b906b2c8013
Removing intermediate container 2b906b2c8013
 ---> 3692f06d3595
Step 3/6 : COPY ./app/* /usr/src/app/
 ---> a4386d8fe2a4
Step 4/6 : WORKDIR /usr/src/app
Removing intermediate container 2eca95d5e015
 ---> 9df0e9407e22
Step 5/6 : RUN npm install
 ---> Running in 588f8dd6f2a5
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN aci-helloworld@1.0.0 No description
npm WARN aci-helloworld@1.0.0 No repository field.
npm WARN aci-helloworld@1.0.0 No license field.

added 51 packages in 3.292s
Removing intermediate container 588f8dd6f2a5
 ---> 4364318bfac7
Step 6/6 : CMD node /usr/src/app/index.js
 ---> Running in b90714f3864b
Removing intermediate container b90714f3864b
 ---> 7b0a5ed92e6b
Successfully built 7b0a5ed92e6b
Successfully tagged aci-hello:latest
```

and here is one when running the image:

```sh
docker run -it -p 8080:80  aci-hello
listening on port 80
::ffff:172.17.0.1 - - [14/Dec/2017:22:23:52 +0000] "GET / HTTP/1.1" 200 1663 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.24 Safari/537.36"
::ffff:172.17.0.1 - - [14/Dec/2017:22:23:52 +0000] "GET /favicon.ico HTTP/1.1" 404 150 "http://localhost:8080/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.24 Safari/537.36"
```
